### PR TITLE
Fix error relating to missing app module

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -5,11 +5,13 @@ services:
     container_name: converter-develop
     environment:
       NODE_ENV: dev
-      CT_URL: http://mymachine:9000
-      LOCAL_URL: http://mymachine:4100
-      PORT: 4100
-      API_VERSION: v1
-      CT_REGISTER_MODE: auto
+        CT_URL: http://mymachine:9000
+        NODE_PATH: app/src
+        LOCAL_URL: http://mymachine:4100
+        PORT: 4100
+        API_VERSION: v1
+        FASTLY_ENABLED: "false"
+        CT_REGISTER_MODE: auto
     command: develop
     volumes:
       - ./app:/opt/converter/app


### PR DESCRIPTION
This PR fixes the following error Cannot find module 'app' when trying to use docker for local development. This error occurs due to the NODE_PATH environment variable not being set.